### PR TITLE
Bugfix to unit count display

### DIFF
--- a/src/main/battlecode/client/viewer/render/DrawHUD.java
+++ b/src/main/battlecode/client/viewer/render/DrawHUD.java
@@ -293,7 +293,7 @@ class DrawHUD {
   	String numString = String.format("%03d", number);
   	for (int i = 0; i < 3; i++) {
 	    int digit = Integer.decode(numString.substring(i, i + 1));
-	    if(digit != 0 || i == 2) {
+	    if((digit != 0) || (i == 1 && number >= 100) || (i == 2 && number >= 10)) {
 		g2.drawImage(numbers[digit],
 			     textScaleSmall, null);
 	    }


### PR DESCRIPTION
Fixes missing central 0 in three-digit numbers like 106.

This change will also show no unit count at all if the unit count is 0, which I like but is different from the current behavior.
